### PR TITLE
Revert "camera: Fix inclusion of CameraParametersExtra.h"

### DIFF
--- a/camera/CameraParameters.cpp
+++ b/camera/CameraParameters.cpp
@@ -21,7 +21,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <camera/CameraParameters.h>
-#include "camera/CameraParametersExtra.h"
+#include <camera/CameraParametersExtra.h>
 #include <system/graphics.h>
 
 namespace android {

--- a/include/camera/CameraParameters.h
+++ b/include/camera/CameraParameters.h
@@ -19,7 +19,7 @@
 
 #include <utils/KeyedVector.h>
 #include <utils/String8.h>
-#include "camera/CameraParametersExtra.h"
+#include <camera/CameraParametersExtra.h>
 
 namespace android {
 


### PR DESCRIPTION
This reverts commit 334b84bbd2512facb132f6a31126d241f49b98fd.
It does exactly the opposite of what's requested. See
http://gcc.gnu.org/onlinedocs/gcc-2.95.3/cpp_1.html#SEC6 , quotes
make the local copy take priority

Change-Id: I3f94e8d00fbd0388a4a6424573cce978e7f59425
